### PR TITLE
Document requirement for no task events in order to use mark_complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ tasks = ReclaimTask.search(title="My task")
 # If we have the task ID we can get the task directly
 task = ReclaimTask.get(12345)
 
+# Mark the task incomplete
+task.mark_incomplete()
+
+# Move start date to future to remove all events
+# This is needed to mark it complete if still scheduled
+task.start_date = "2050-01-01T07:00:00.000Z"
+task.due_date = "2050-01-31T17:00:00.000Z"
+
+# Mark the task complete
+task.mark_complete()
+
 ```
 
 ### Deleting tasks

--- a/reclaim_sdk/models/task.py
+++ b/reclaim_sdk/models/task.py
@@ -240,7 +240,7 @@ class ReclaimTask(ReclaimModel):
 
     def mark_complete(self) -> None:
         """
-        Marks the task as complete.
+        Marks the task as complete. Only works if task has no events scheduled.
         """
         with ReclaimAPICall(self) as client:
             url = f"{client._api_url}/api/planner/done/task/{self.id}"


### PR DESCRIPTION
I was doing some testing and was having trouble for a while to get `mark_complete` to work. It turns out Reclaim will only mark the event complete when calling it if there are no events scheduled for that task.

I only noticed that this was a requirement after seeing how the `TestTaskCRUD` case sets the start and end dates to 2050, which will mean nothing is scheduled in that time.

It's not the most elegant way to unschedule all the tasks, so there's likely a better way to do it but this is the first working one I've seen so far.

This PR documents that requirement so that others using the SDK will know the conditions required to use `mark_complete`.

This SDK is awesome and I'm excited to contribute however I can.