### PR TITLE
Fixed incorrect time format in `log_work`

### DIFF
--- a/reclaim_sdk/resources/task.py
+++ b/reclaim_sdk/resources/task.py
@@ -1,5 +1,5 @@
 from pydantic import Field, field_validator
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import ClassVar, Optional
 from enum import Enum
 from reclaim_sdk.resources.base import BaseResource
@@ -149,7 +149,11 @@ class Task(BaseResource):
     def log_work(self, minutes: int, end: Optional[datetime] = None) -> None:
         params = {"minutes": minutes}
         if end:
-            params["end"] = end.isoformat()
+            # Convert local time to Zulu time
+            end = end.astimezone(timezone.utc)
+            # Truncate timestamp to match required format
+            params["end"] = end.isoformat()[:-9] + "Z"
+
         response = self._client.post(
             f"/api/planner/log-work/task/{self.id}", params=params
         )


### PR DESCRIPTION
The time format for `log_work` appears to have changed, resulting in a `BadRequest` error with the original code. Upon some reverse engineering, I found that the time must meet the following requirements:

- It must be expressed in Zulu time, using a `Z` suffix rather than the `+00:00` format that Python provides.
- The microseconds must be limited to 3 digits of precision, instead of the default 6 digits from Python.

I have updated the code to address these requirements.